### PR TITLE
Implement Use my location and more strongly encourage users to locate business

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
                         <form id='find'>
                             <input class='col8' id='address' placeholder='' data-i18n="[placeholder]step1.addr"/>
                             <button class='col4' id='findme' data-i18n="step1.button"></button>
+                            <br />
+                            Or <a id="use_my_location" href="#" onclick="return false">use my current location</a>.
                         </form>
                     </div>
                     <br />

--- a/index.html
+++ b/index.html
@@ -52,10 +52,11 @@
 
                 <div class='center pad2'>
                     <p id="couldnt-find" style='display: none;' data-i18n="[html]step1.fail"></p>
-                    <p id="success" style='display: none;'></p>
                 </div>
                 <div class='col12'>
-                    <div class='col12' id='findme-map' style="margin-bottom: 500px;"></div>
+                    <div class='col12' id='findme-map'></div>
+                    <p id="success" class="center" style='display: none; margin-bottom: 500px;'></p>
+
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
                     <p id="success" style='display: none;'></p>
                 </div>
                 <div class='col12'>
-                    <div class='col12' id='findme-map'></div>
+                    <div class='col12' id='findme-map' style="margin-bottom: 500px;"></div>
                 </div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -38,7 +38,6 @@
             <div class='col12' id='address-step'>
                 <div class='center pad2'>
                     <span id='instructions' data-i18n="step1.desc"></span>
-                    <p id="couldnt-find" style='display: none;' data-i18n="[html]step1.fail"></p>
                 </div>
                 <div class='col12'>
                     <div class='pad1'>
@@ -49,8 +48,13 @@
                             Or <a id="use_my_location" href="#" onclick="return false">use my current location</a>.
                         </form>
                     </div>
-                    <br />
-                    <br />
+                </div>
+
+                <div class='center pad2'>
+                    <p id="couldnt-find" style='display: none;' data-i18n="[html]step1.fail"></p>
+                    <p id="success" style='display: none;'></p>
+                </div>
+                <div class='col12'>
                     <div class='col12' id='findme-map'></div>
                 </div>
             </div>

--- a/js/site.js
+++ b/js/site.js
@@ -59,7 +59,7 @@ $("#use_my_location").click(function (e) {
 
             $('#success').html(successString);
             $('#success').show();
-            window.scrollTo(0, $('#success').position().top - 10);
+            window.scrollTo(0, $('#address').position().top - 30);
             $('.step-2 a').attr('href', '#details');
         }, function (error) {
             $("#couldnt-find").show();
@@ -87,7 +87,7 @@ $("#find").submit(function(e) {
 
             $('#success').html(successString);
             $('#success').show();
-            window.scrollTo(0, $('#success').position().top - 10);
+            window.scrollTo(0, $('#address').position().top - 30);
             $('.step-2 a').attr('href', '#details');
         } else {
             $("#couldnt-find").show();

--- a/js/site.js
+++ b/js/site.js
@@ -46,6 +46,8 @@ function zoom_to_point(chosen_place, map, marker) {
     map.setView(chosen_place, 18, {animate: true});
 }
 $("#use_my_location").click(function (e) {
+    $("#couldnt-find").hide();
+    $("#success").hide();
     if ("geolocation" in navigator) {
         navigator.geolocation.getCurrentPosition(function(position) {
             var point = {
@@ -55,16 +57,21 @@ $("#use_my_location").click(function (e) {
 
             zoom_to_point(point, findme_map, findme_marker);
 
-            $('#instructions').html(successString);
+            $('#success').html(successString);
+            $('#success').show();
+            window.scrollTo(0, $('#success').position().top - 10);
             $('.step-2 a').attr('href', '#details');
+        }, function (error) {
+            $("#couldnt-find").show();
         });
     } else {
-      /* geolocation IS NOT available */
+      $("#couldnt-find").show();
     }
 });
 $("#find").submit(function(e) {
     e.preventDefault();
     $("#couldnt-find").hide();
+    $("#success").hide();
     var address_to_find = $("#address").val();
     if (address_to_find.length === 0) return;
     var qwarg = {
@@ -78,7 +85,9 @@ $("#find").submit(function(e) {
         if (data.length > 0) {
             zoom_to_point(data[0], findme_map, findme_marker);
 
-            $('#instructions').html(successString);
+            $('#success').html(successString);
+            $('#success').show();
+            window.scrollTo(0, $('#success').position().top - 10);
             $('.step-2 a').attr('href', '#details');
         } else {
             $("#couldnt-find").show();

--- a/js/site.js
+++ b/js/site.js
@@ -36,6 +36,32 @@ $("#category").select2({
     }
 });
 
+function zoom_to_point(chosen_place, map, marker) {
+    console.log(chosen_place);
+
+    marker.setOpacity(1);
+    marker.setLatLng([chosen_place.lat, chosen_place.lon]);
+
+
+    map.setView(chosen_place, 18, {animate: true});
+}
+$("#use_my_location").click(function (e) {
+    if ("geolocation" in navigator) {
+        navigator.geolocation.getCurrentPosition(function(position) {
+            var point = {
+                lat: position.coords.latitude,
+                lon: position.coords.longitude
+            }
+
+            zoom_to_point(point, findme_map, findme_marker);
+
+            $('#instructions').html(successString);
+            $('.step-2 a').attr('href', '#details');
+        });
+    } else {
+      /* geolocation IS NOT available */
+    }
+});
 $("#find").submit(function(e) {
     e.preventDefault();
     $("#couldnt-find").hide();
@@ -50,17 +76,7 @@ $("#find").submit(function(e) {
     $("#findme").addClass("loading");
     $.getJSON(url, function(data) {
         if (data.length > 0) {
-            var chosen_place = data[0];
-            console.log(chosen_place);
-
-            var bounds = new L.LatLngBounds(
-                [+chosen_place.boundingbox[0], +chosen_place.boundingbox[2]],
-                [+chosen_place.boundingbox[1], +chosen_place.boundingbox[3]]);
-
-            findme_map.fitBounds(bounds);
-
-            findme_marker.setOpacity(1);
-            findme_marker.setLatLng([chosen_place.lat, chosen_place.lon]);
+            zoom_to_point(data[0], findme_map, findme_marker);
 
             $('#instructions').html(successString);
             $('.step-2 a').attr('href', '#details');

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -39,7 +39,7 @@
     "row4a": "Back to initial screen"
   },
   "messages": {
-    "success": "Found it! Click and drag the marker on your business place position, so you'll be ready to <a href='#details'>add more details</a>.",
+    "success": "<strong>Found it!</strong> Move the marker until it is <strong>exactly on your business</strong>.<br />When you are happy, we can start to <a href='#details'>add more details</a>.",
     "loadingText": "Searching..."
   }
 }


### PR DESCRIPTION
Fixes #25 and maybe fixes #9 

There is now a 'use my location' control:
![image](https://cloud.githubusercontent.com/assets/365751/23089771/b72d960e-f5de-11e6-9001-c673ba6f6586.png)

After a successful address or geocoding event; the user is pushed to the map and given stronger instructions on locating their business.
![image](https://cloud.githubusercontent.com/assets/365751/23089767/a5acc79c-f5de-11e6-91fb-94e30ccda0fc.png)

The success messages are now below the map controls; to sort of act as a 'Next' button more clearly.

The failure message is below the address but above the map now, so the user can repeat the search/geocoding lookup.