### PR TITLE
Add a simple facebook auth and prompt for page URI (WIP for feedback)

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,5 +94,54 @@
             </div>
         </div>
         <script src='js/site.js'></script>
+        <script>
+          window.fbAsyncInit = function() {
+            FB.init({
+              appId      : '230563574073994',
+              xfbml      : false,
+              version    : 'v2.8'
+            });
+            FB.AppEvents.logPageView();
+          };
+
+          (function(d, s, id){
+             var js, fjs = d.getElementsByTagName(s)[0];
+             if (d.getElementById(id)) {return;}
+             js = d.createElement(s); js.id = id;
+             js.src = "//connect.facebook.net/en_US/sdk.js";
+             fjs.parentNode.insertBefore(js, fjs);
+           }(document, 'script', 'facebook-jssdk'));
+        </script>
+        <a id='fblogin'>Facebook auth</a>
+        <script>
+        function fetch_facebook_page_url() {
+
+            var page_url = 'https://www.facebook.com/pages/Adelaide-Hills-Stationery/517688011766722?fref=ts';
+            var parts = page_url.split("/");
+            var fbid = parts[parts.length-1].split("?")[0];
+
+            FB.api(
+              '/' + fbid + '/',
+              'GET',
+              {"fields":"id,name,about,single_line_address,website,is_always_open,payment_options,hours,location,category,category_list,company_overview,description,general_info,is_permanently_closed,link,parking,phone,place_type,public_transit,store_location_descriptor"},
+              function(response) {
+                  console.log(response);
+              }
+            );
+
+        }
+
+        $('#fblogin').click(function () {
+            FB.getLoginStatus(function(response) {
+              if (response.status === 'connected') {
+                    fetch_facebook_page_url();
+              } else {
+                FB.login(function (response) {
+                    fetch_facebook_page_url();
+                });
+              }
+            });
+        });
+        </script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                             <input class='col8' id='address' placeholder='' data-i18n="[placeholder]step1.addr"/>
                             <button class='col4' id='findme' data-i18n="step1.button"></button>
                             <br />
-                            Or <a id="use_my_location" href="#" onclick="return false">use my current location</a>.
+                            Or <a id="use_my_location" href="#" onclick="return false">use my current location</a>, <a id='fblogin' href='#" onclick="return false">sync a facebook business page</a>.
                         </form>
                     </div>
                 </div>
@@ -111,37 +111,6 @@
              js.src = "//connect.facebook.net/en_US/sdk.js";
              fjs.parentNode.insertBefore(js, fjs);
            }(document, 'script', 'facebook-jssdk'));
-        </script>
-        <a id='fblogin'>Facebook auth</a>
-        <script>
-        function fetch_facebook_page_url() {
-
-            var page_url = 'https://www.facebook.com/pages/Adelaide-Hills-Stationery/517688011766722?fref=ts';
-            var parts = page_url.split("/");
-            var fbid = parts[parts.length-1].split("?")[0];
-
-            FB.api(
-              '/' + fbid + '/',
-              'GET',
-              {"fields":"id,name,about,single_line_address,website,is_always_open,payment_options,hours,location,category,category_list,company_overview,description,general_info,is_permanently_closed,link,parking,phone,place_type,public_transit,store_location_descriptor"},
-              function(response) {
-                  console.log(response);
-              }
-            );
-
-        }
-
-        $('#fblogin').click(function () {
-            FB.getLoginStatus(function(response) {
-              if (response.status === 'connected') {
-                    fetch_facebook_page_url();
-              } else {
-                FB.login(function (response) {
-                    fetch_facebook_page_url();
-                });
-              }
-            });
-        });
         </script>
     </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
                             <input class='col8' id='address' placeholder='' data-i18n="[placeholder]step1.addr"/>
                             <button class='col4' id='findme' data-i18n="step1.button"></button>
                             <br />
-                            Or <a id="use_my_location" href="#" onclick="return false">use my current location</a>, <a id='fblogin' href='#" onclick="return false">sync a facebook business page</a>.
+                            Or <a id="use_my_location" href="#" onclick="return false">use my current location</a>, <a id='fblogin' href='#' onclick="return false">sync a facebook business page</a>.
                         </form>
                     </div>
                 </div>

--- a/js/site.js
+++ b/js/site.js
@@ -141,3 +141,39 @@ function clearFields() {
     $("#category").val('');
     $("#address").val('');
 }
+
+
+function fetch_facebook_page_url() {
+
+    var page_url = prompt("Copy/paste in your businesses facebook page url; ie: https://www.facebook.com/pages/Adelaide-Hills-Stationery/517688011766722?fref=ts'");
+    var parts = page_url.split("/");
+    var fbid = parts[parts.length-1].split("?")[0];
+
+    FB.api(
+      '/' + fbid + '/',
+      'GET',
+      {"fields":"id,name,about,single_line_address,website,is_always_open,payment_options,hours,location,category,category_list,company_overview,description,general_info,is_permanently_closed,link,parking,phone,place_type,public_transit,store_location_descriptor"},
+      function(response) {
+          $('#address').val(response.single_line_address);
+          $("#find").submit();
+
+          $('#name').val(response.name);
+          $('#phone').val(response.phone);
+          $('#website').val(response.link);
+          $('#opening_hours').val(response.hours);
+      }
+    );
+
+}
+
+$('#fblogin').click(function () {
+    FB.getLoginStatus(function(response) {
+      if (response.status === 'connected') {
+            fetch_facebook_page_url();
+      } else {
+        FB.login(function (response) {
+            fetch_facebook_page_url();
+        });
+      }
+    });
+});


### PR DESCRIPTION
#19 

- [ ] Needs i18n work
- [ ] Probably want to swap from javascript prompt() to a form input
- [ ] Need to trial with a wide varierty of pages uris and invalid input.


![image](https://cloud.githubusercontent.com/assets/365751/23091834/1cf17d54-f60f-11e6-9933-e3fc450ab3cd.png)

![image](https://cloud.githubusercontent.com/assets/365751/23091849/55378fc8-f60f-11e6-80c0-844444037f4d.png)

![image](https://cloud.githubusercontent.com/assets/365751/23091856/6354a834-f60f-11e6-89d8-08e8e26c4f8d.png)

I had to register a facebook app to get the id, can add invites to relevant people to be admins if wanted
