### PR TITLE
Rephrase note_body to make some keys copyable

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -128,16 +128,17 @@ $("#collect-data-done").click(function() {
     location.hash = '#done';
 
     var note_body =
-        "onosm.org submitted note from a business:\n" +
-        "name: " + $("#name").val() + "\n" +
-        "phone: " + $("#phone").val() + "\n" +
-        "website: " + $("#website").val() + "\n" +
-        "twitter: " + $("#twitter").val() + "\n" +
-        "facebook: " + $("#facebook").val() + "\n" +
-        "email: " + $("#email").val() + "\n" +
-        "hours: " + $("#opening_hours").val() + "\n" +
-        "category: " + $("#category").val().join(", ") + "\n" +
-        "address: " + $("#address").val(),
+        "onosm.org submitted note from a business:\n\n" +
+        "name=" + $("#name").val() + "\n" +
+        "website=" + $("#website").val() + "\n" +
+        "phone=" + $("#phone").val() + "\n" +
+        "twitter=" + $("#twitter").val() + "\n" +
+        "facebook=" + $("#facebook").val() + "\n\n" +
+        "Other info (Needs to be adapted to OSM tagging standards):\n" +
+        "  Address: " + $("#address").val() + "\n" +
+        "  Hours: " + $("#opening_hours").val() + "\n" +
+        "  Category: " + $("#category").val().join(", ") + "\n" +
+        "  Email: " + $("#email").val(),
         latlon = findme_marker.getLatLng(),
         note_data = {
             lat: latlon.lat,


### PR DESCRIPTION
Some of the pieces of info gathered can generally be directly copied into OSM tags, while others require adapting their format, or making a more nuanced decision about whether to include them. It'd be better to distinguish these, to make it easier to process the resulting businesses.

The ones I thought were copyable are: `name`, `website`, `phone`, `twitter` and `facebook`. Email could be, too -- but I don't think emails should actually be included in most cases (unless the business can be verified from street view images or surveys, *AND* the person adding the business has emailed the address and received a response confirming it as valid).

The other fields have more complex formatting on OSM, so while it'd be good to eventually have this tool handle them better, for now, they need to be processed manually.

I'm not sure whether or not to add the explicit warning about "Needs to be adapted to OSM tagging standards" -- but it seemed better to have than not.