### PR TITLE
Fix typo ("dass" -> "das")

### DIFF
--- a/locales/de/translation.json
+++ b/locales/de/translation.json
@@ -1,7 +1,7 @@
 ﻿{
   "app": {
     "title": "On OpenStreetMap",
-    "desc": "OpenStreetMap ist eine offene, globale Karte, die von Menschen überall auf der Welt zur Navigation und zur Suche nach lokalen Geschäften genutzt wird. Es ist einfach und kostenlos, dass eigene Geschäft auf die Karte zu bringen!",
+    "desc": "OpenStreetMap ist eine offene, globale Karte, die von Menschen überall auf der Welt zur Navigation und zur Suche nach lokalen Geschäften genutzt wird. Es ist einfach und kostenlos, das eigene Geschäft auf die Karte zu bringen!",
     "footer": "Quellcode erhältlich auf <a href='https://github.com/osmlab/onosm.org'>GitHub</a>"
   },
   "step1": {


### PR DESCRIPTION
We need an article ("das"), not a conjunction ("dass") in the phrase "das eigene Geschäft".

Sorry for the small PR, it was just a thing that jumped to my attention when visiting the website, so I thought I'd propose a fix.