### PR TITLE
Include category/description/social/payment in submitted notes; limit description to 255 chars

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
               <div class="input-group-prepend">
                 <span class="input-group-text"><i class="twa twa-convenience-store"></i></span>
               </div>
-              <input id='categoryalt' type='text' placeholder='' class="form-control" data-i18n="[placeholder]step2.cataltplaceholder" />
+              <input id='categoryalt' type='text' placeholder='' maxlength="255" class="form-control" data-i18n="[placeholder]step2.cataltplaceholder" />
             </div>
           </diV>
         </div>

--- a/js/site.js
+++ b/js/site.js
@@ -584,15 +584,15 @@ function disableDelivery() { $("#delivery").attr("disabled", true); $("#delivery
 function enableDelivery() { $("#delivery").removeAttr("disabled"); $("#delivery_description").removeAttr("disabled"); $("#label-delivery-check").html(i18n.t('step2.yes')); }
 
 function getNoteBody() {
-  var paymentIds = [],
-    paymentTexts = [];
+  var paymentIds = [];
   $.each($("#payment").select2("data"), function (_, e) {
     paymentIds.push(e.id);
-    paymentTexts.push(e.text);
   });
 
   var note_body = "onosm.org submitted note from a business:\n";
   if ($("#name").val()) note_body += "name=" + $("#name").val() + "\n";
+  if ($("#category").val()) note_body += "category=" + $("#category").val() + "\n";
+  if ($("#categoryalt").val()) note_body += "description=" + $("#categoryalt").val() + "\n";
   if ($("#hnumberalt").val()) note_body += "addr:housenumber=" + $("#hnumberalt").val() + "\n";
   if ($("#addressalt").val()) note_body += "addr:street=" + $("#addressalt").val() + "\n";
   if ($("#placenamealt").val()) note_body += "addr:place=" + $("#placenamealt").val() + "\n";
@@ -601,8 +601,10 @@ function getNoteBody() {
   if ($("#phone").val()) note_body += "phone=" + $("#phone").val() + "\n";
   // fixme - this should be default to an empty string or be escaped
   if ($("#website").val()) note_body += "website=" + $("#website").val() + "\n";
+  if ($("#social").val()) note_body += "social=" + $("#social").val() + "\n";
   if ($("#opening_hours").val()) note_body += "opening_hours=" + $("#opening_hours").val() + "\n";
   if ($("#wheel").val()) note_body += "wheelchair=" + $("#wheel").val() + "\n";
+  paymentIds.forEach(function (id) { note_body += id + "\n"; });
 
   // delivery
   if ($("input:checked[name=delivery-check]").val() && $("#delivery").val() != "")


### PR DESCRIPTION
## Summary
Fixes #156.

While looking at #156 I found that the category, description (`categoryalt`), social media, and payment fields were being collected in the form but silently dropped when building the note body in `getNoteBody()` — the `paymentIds`/`paymentTexts` arrays were even computed and then never used. This confirmed against the live `www.onosm.org/js/site.js` too, so it's an existing production bug, not just a gh-pages issue.

Since #156 is specifically about the description field reaching the note in a form OSM contributors can copy over, this PR:
- Adds `category=`, `description=` (from the free-text `categoryalt`/"Description" field), `social=`, and the selected `payment:*=yes` tags to the submitted note body
- Adds `maxlength="255"` to the description input, matching OSM's typical tag value length limit, as requested in #156

## Test plan
- [x] Reviewed `getNoteBody()` manually for correct tag key names against existing conventions in the function
- [x] Confirmed `payment.json` entries already store the full `key=value` string as `id`, so appending `paymentIds` directly is correct
- [x] Verified the edited JS parses without syntax errors