### PR TITLE
Add source hashtag to submitted notes

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -622,6 +622,12 @@ function getNoteBody() {
   if ($("#takeaway_description").val())
     note_body += `takeaway:description=${$("#takeaway_description").val()}\n`;
 
+  // Source hashtag so notes from onosm.org (as opposed to one of its forks)
+  // can be found/filtered, and the date lets us tell whether a given issue
+  // has since been fixed. See https://github.com/osmlab/onosm.org/issues/117
+  var today = new Date().toISOString().slice(0, 10);
+  note_body += "\n#OnOSM.org-" + today;
+
   return note_body;
 }
 


### PR DESCRIPTION
## Summary
Fixes #117.

Appends a `#OnOSM.org-YYYY-MM-DD` hashtag to the end of every submitted note body, so notes created by onosm.org (as opposed to one of its forks) can be found/filtered, and the date makes it possible to tell whether a particular issue (e.g. the bad-marker-placement problems in #103) has since been fixed.

One deliberate deviation from the issue's exact proposal: it suggested `OnOSM.org-YYYY/MM/DD`, but OSM hashtag conventions don't handle `/` well (tools typically only recognize alphanumeric/`-`/`_` within a hashtag token), so I used `-` as the date separator instead to keep it as one clean, parseable hashtag.

## Test plan
- [x] Verified the edited `getNoteBody()` parses without syntax errors
- [x] Confirmed the date formatting produces `YYYY-MM-DD` (e.g. `#OnOSM.org-2026-07-13`)