### PR TITLE
Validate location is set before allowing note submission

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
         <p id="map-information" class="alert alert-warning mt-2" role="alert" style='display: none;'></p>
       </div>
       <div id='findme-map'></div>
-      <a class="btn btn-primary btn-lg text-white w-100 mt-3 text-uppercase disabled" id="continue" href="#details" data-i18n="step1.continue">
+      <a class="btn btn-primary btn-lg text-white w-100 mt-3 text-uppercase disabled" id="continue" href="#details" aria-disabled="true" tabindex="-1" data-i18n="step1.continue">
         Move to next step
       </a>
     </div>

--- a/js/site.js
+++ b/js/site.js
@@ -243,7 +243,7 @@ $("#find").submit(function (e) {
               $("#map-information").show();
               $('.step-2 a').attr('href', '#details');
               $('#step2').removeClass("disabled");
-              $('#continue').removeClass("disabled");
+              setContinueEnabled(true);
             })
 
             .catch(err => {
@@ -367,7 +367,7 @@ function updateAddressInfo(chosen_place) {
   } else {
     $('#step2').removeClass("disabled");
     $('.step-2 a').attr('href', '#details');
-    $('#continue').removeClass("disabled");
+    setContinueEnabled(true);
     $("#address").addClass("is-valid");
     $("#address").removeClass("is-invalid");
   }
@@ -631,15 +631,29 @@ function hasMinimumData() {
   return $("#name").val() && $("#city").val() && ($("#category").val() || $("#categoryalt").val());
 }
 
+// hasValidLocation returns true if the user has actually searched for and/or
+// placed a marker for this note. Relying only on hash-based navigation to
+// keep users off step 2 without a location isn't enough on its own -- e.g. a
+// keyboard user can activate the visually-"disabled" Continue link, or a
+// stale marker from a previous note can be left in place -- so this is
+// checked again immediately before a note is submitted.
+// https://github.com/osmlab/onosm.org/issues/103
+function hasValidLocation() {
+  return findme_marker !== null && activeMarkerLatLng !== null;
+}
+
 $("#collect-data-done").click(function (event) {
   // https://stackoverflow.com/questions/18274383/ajax-post-working-in-chrome-but-not-in-firefox
   event.preventDefault();
 
   // Don't submit if the form is invalid
-  if (!hasMinimumData()) {
+  if (!hasMinimumData() || !hasValidLocation()) {
     event.stopPropagation();
     $("#required_info_alert").removeClass("alert-info");
     $("#required_info_alert").addClass("alert-danger");
+    if (!hasValidLocation()) {
+      location.hash = '';
+    }
     return;
   }
 
@@ -660,6 +674,18 @@ $("#collect-data-done").click(function (event) {
   });
 });
 
+// setContinueEnabled toggles the "Continue" link between its disabled and
+// enabled states. The "disabled" class alone only blocks mouse clicks
+// (via pointer-events: none); aria-disabled/tabindex are needed so the link
+// can't be activated by keyboard (or an errant Enter) while a location
+// hasn't actually been set. https://github.com/osmlab/onosm.org/issues/103
+function setContinueEnabled(enabled) {
+  $('#continue')
+    .toggleClass('disabled', !enabled)
+    .attr('aria-disabled', String(!enabled))
+    .attr('tabindex', enabled ? null : '-1');
+}
+
 function clearFields() {
   $("#form")[0].reset();
   $("#address").val("");
@@ -668,4 +694,6 @@ function clearFields() {
   $('#delivery-check').val("");
   $('#delivery-check').prop('indeterminate', true);
   disableDelivery();
+  $('#step2').addClass("disabled");
+  setContinueEnabled(false);
 }


### PR DESCRIPTION
## Summary
Addresses part of #103 (notes created with bad/duplicate locations, e.g. the repeated coordinates reported in the thread).

While looking through the submission code, I found the location was never actually validated at submit time. The only thing preventing a note from being created without a real location was a side effect of the `hashchange` handler (`if (activeMarkerLatLng == null) location.hash = ''`), which only runs when a `hashchange` **event** fires — it doesn't run on direct DOM interaction, and it wasn't re-checked at the moment of submission.

Two concrete gaps this closes:
1. **The "Continue" link was only visually disabled.** It's a plain `<a>` with Bootstrap's `.disabled` class, which sets `pointer-events: none` (blocks mouse clicks) but does nothing to stop keyboard activation (Tab + Enter) or other navigation paths that don't reliably fire `hashchange` (direct URL entry, back/forward, bfcache restores). Added `aria-disabled="true"` + `tabindex="-1"` when disabled, toggled properly alongside the existing `disabled` class via a new `setContinueEnabled()` helper.
2. **`hasMinimumData()` never checked the location at all**, and the submit handler pulled `lat`/`lon` straight from `findme_marker.getLatLng()` unconditionally. If a user reached step 2 without a valid `activeMarkerLatLng` (e.g. via the gap above), and `findme_marker` still existed from a *previous* note, the note would silently reuse that stale marker position. Added `hasValidLocation()`, checked alongside `hasMinimumData()` before submission; if it fails, the user is sent back to step 1 to search again.
3. As a related fix, `clearFields()` (called after each successful submission) now re-disables the Continue button/step2 tab, since previously it stayed enabled forever after the first successful search — meaning a second note could reach step 2 immediately without searching again at all.

## Test plan
- [x] Verified `aria-disabled`/`tabindex` render correctly on the Continue link in the static HTML
- [x] Verified edited JS parses without syntax errors (`node --check js/site.js`)
- [x] Traced through the click handler, hashchange handler, and clearFields to confirm the button is disabled by default, enabled only after a successful search, and re-disabled after each note is submitted