### PR TITLE
Collapse delivery and takeaway detail fields until relevant

### DIFF
--- a/index.html
+++ b/index.html
@@ -277,18 +277,16 @@
 
         <div class="row">
           <div class="form-group col">
-            <label for='delivery' data-i18n="step2.delivery"></label>
-            <div class="input-group">
-              <div class="input-group-prepend">
-                <div class="input-group-text">
-                  <div class="custom-control custom-checkbox">
-                    <input type="checkbox" class="custom-control-input" id="delivery-check" name="delivery-check">
-                    <label for="delivery-check" id="label-delivery-check" class="custom-control-label mb-0 ml-2" data-i18n="step2.no"></label>
-                  </div>
-                </div>
-              </div>
-              <input id='delivery' type='text' placeholder='' class="form-control" data-i18n="[placeholder]step2.deliveryplaceholder" />
+            <div class="custom-control custom-checkbox">
+              <input type="checkbox" class="custom-control-input" id="delivery-check" name="delivery-check">
+              <label for="delivery-check" class="custom-control-label" data-i18n="step2.delivery"></label>
             </div>
+          </div>
+        </div>
+        <div class="row d-none" id="delivery-details">
+          <div class="form-group col">
+            <label for='delivery' data-i18n="step2.deliverydesc"></label>
+            <input id='delivery' type='text' placeholder='' class="form-control" data-i18n="[placeholder]step2.deliveryplaceholder" />
           </div>
           <div class="form-group col-sm-6">
             <label for='delivery_description' data-i18n="step2.delivery_description"></label>
@@ -317,7 +315,7 @@
               </div>
             </div>
           </div>
-          <div class="form-group col-sm-6">
+          <div class="form-group col-sm-6 d-none" id="takeaway-description-group">
             <label for='takeaway_description' data-i18n="step2.takeaway_description"></label>
             <input id='takeaway_description' type='text' placeholder='' class="form-control" data-i18n="[placeholder]step2.takeaway_descriptionplaceholder" />
           </div>

--- a/js/site.js
+++ b/js/site.js
@@ -580,8 +580,16 @@ $('#delivery-check').prop('indeterminate', true);
 $(function () { deliveryCheck(); $("#delivery-check").click(deliveryCheck); });
 function deliveryCheck() { if (this.checked) { enableDelivery(); } else { disableDelivery(); } }
 
-function disableDelivery() { $("#delivery").attr("disabled", true); $("#delivery_description").attr("disabled", true); $("#label-delivery-check").html(i18n.t('step2.no')); }
-function enableDelivery() { $("#delivery").removeAttr("disabled"); $("#delivery_description").removeAttr("disabled"); $("#label-delivery-check").html(i18n.t('step2.yes')); }
+function disableDelivery() { $("#delivery").attr("disabled", true); $("#delivery_description").attr("disabled", true); $("#delivery-details").addClass("d-none"); }
+function enableDelivery() { $("#delivery").removeAttr("disabled"); $("#delivery_description").removeAttr("disabled"); $("#delivery-details").removeClass("d-none"); }
+
+// Show the takeaway description field only when takeaway is offered.
+// https://github.com/osmlab/onosm.org/issues/106
+$(function () {
+  $('input[name=takeaway]').change(function () {
+    $('#takeaway-description-group').toggleClass('d-none', this.value === 'no');
+  });
+});
 
 function getNoteBody() {
   var paymentIds = [];
@@ -700,6 +708,7 @@ function clearFields() {
   $('#delivery-check').val("");
   $('#delivery-check').prop('indeterminate', true);
   disableDelivery();
+  $('#takeaway-description-group').addClass("d-none");
   $('#step2').addClass("disabled");
   setContinueEnabled(false);
 }


### PR DESCRIPTION
## Summary
Fixes #106.

The delivery and takeaway sections take up a lot of screen space even when a business doesn't offer them. Per the issue, extra detail fields now stay collapsed until the corresponding service is actually toggled on:

- **Delivery**: split the "Is there a delivery service?" checkbox out from the detail input group it was previously embedded in. The delivery hours/notes fields (`#delivery`, `#delivery_description`) now live in a separate `#delivery-details` row that's hidden (`d-none`) by default and only revealed when the checkbox is checked, via the existing `enableDelivery()`/`disableDelivery()` functions.
- **Takeaway**: the existing yes/no/only radio toggle now controls visibility of the takeaway description field — hidden for "no", shown for "yes"/"only".
- Both reset back to their collapsed default state in `clearFields()`, so a second note doesn't inherit the previous note's expanded/collapsed state.

I removed the dynamic "Yes"/"No" text swap on the delivery checkbox's label (`#label-delivery-check`) since the label now just states the question ("Is there a delivery service?") and the collapse/expand itself communicates the current state — this also let me drop an unused translation-lookup call.

## Test plan
- [x] Verified both detail sections render with `d-none` by default in the static HTML
- [x] Verified edited JS parses without syntax errors (`node --check js/site.js`)
- [x] Confirmed the `deliverydesc` translation key (used as the new label for the delivery hours field) exists in every active locale