### PR TITLE
Small code fixes: JSONP removal, note body sanitization, Leaflet CSS pin, i18n bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
   <!-- SELECT 2  CSS-->
   <link rel='stylesheet' type='text/css' href="https://cdnjs.cloudflare.com/ajax/libs/select2/3.5.4/select2.min.css" />
   <!-- LEAFLET  CSS-->
-  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ==" crossorigin="" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.3/dist/leaflet.css" integrity="sha512-mD70nAW2ThLsWH0zif8JPbfraZ8hbCtjQ+5RU1m4+ztZq6/MymyZeB55pWsi4YAX+73yvcaJyk61mzfYMvtm9w==" crossorigin="" />
   <link rel="stylesheet" href="css/L.Control.Locate.css" />
   <!-- BOOTSTRAP CSS -->
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css" integrity="sha384-Vkoo8x4CGsO3+Hhxv8T/Q5PaXtkKtu6ug5TOeNV6gBiFeWPGFN9MuhOf23Q9Ifjh" crossorigin="anonymous">
@@ -27,12 +27,6 @@
   <link rel="stylesheet" href="css/twemoji.css" />
   <!-- KEEP LAST -->
   <link rel='stylesheet' type='text/css' href='css/style.css' />
-
-
-  <!--[if lt IE 9]>
-         <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.1/leaflet.ie.css" />
-         <link rel="stylesheet" href="css/L.Control.Locate.ie.css"/>
-  <![endif]-->
 
   <!-- LEAFLET  JS-->
   <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.9.3/leaflet.js" integrity="sha512-Dqm3h1Y4qiHUjbhxTuBGQsza0Tfppn53SHlu/uj1f+RT+xfShfe7r6czRf5r2NmllO2aKx+tYJgoxboOkn1Scg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -72,7 +72,7 @@ $(function () {
         // for all options read: https://www.i18next.com/overview/configuration-options
         .init({
             // requires language-only translation for fallback even when country version is present
-            debug: true,
+            debug: false,
             fallbackLng: 'en-US',
             preload: ['en-US'],
             backend: {
@@ -91,8 +91,8 @@ $(function () {
                 }
                 $('#languageSwitcher').append(opt);
             });
-            $('#languageSwitcher').change((a, b, c) => {
-                const chosenLng = $(this).find("option:selected").attr('value');
+            $('#languageSwitcher').change((event) => {
+                const chosenLng = event.target.value;
                 i18next.changeLanguage(chosenLng, () => {
                     $("html").attr("lang", chosenLng);
                     rerender(chosenLng);

--- a/js/site.js
+++ b/js/site.js
@@ -12,18 +12,18 @@ const circleRadiusMeters = 50;
 function reloadLists(language) {
 
   $.getJSON('./locales/' + language + '/categories.json')
-    .success(function (data) {
+    .done(function (data) {
       category_data = data;
     })
     .fail(function () {
       // 404? Fall back to en-US
       $.getJSON('./locales/en-US/categories.json')
-        .success(function (data) {
+        .done(function (data) {
           category_data = data;
         });
     });
 
-  $.getJSON('./locales/' + language + '/payment.json').success(function (data) {
+  $.getJSON('./locales/' + language + '/payment.json').done(function (data) {
     payment_data = data;
   });
 
@@ -390,7 +390,6 @@ function searchAddress(address_to_find) {
 
   var addressSearchUrl = "https://nominatim.openstreetmap.org/search?" + $.param(qwArgNominatim);
 
-  // handle request - should include a timeout
   return new Promise((resolve, reject) => {
     $.ajax({
       'url': addressSearchUrl,
@@ -406,8 +405,8 @@ function searchAddress(address_to_find) {
       'error': function (error) {
         reject(error);
       },
-      'dataType': 'jsonp',
-      'jsonp': 'json_callback'
+      'dataType': 'json',
+      'timeout': 10000
     });
   });
 }
@@ -464,8 +463,8 @@ function searchReverseLookup(position) {
       'error': function (error) {
         reject(error);
       },
-      'dataType': 'jsonp',
-      'jsonp': 'json_callback'
+      'dataType': 'json',
+      'timeout': 10000
     });
   });
 }
@@ -583,6 +582,13 @@ function deliveryCheck() { if (this.checked) { enableDelivery(); } else { disabl
 function disableDelivery() { $("#delivery").attr("disabled", true); $("#delivery_description").attr("disabled", true); $("#label-delivery-check").html(i18n.t('step2.no')); }
 function enableDelivery() { $("#delivery").removeAttr("disabled"); $("#delivery_description").removeAttr("disabled"); $("#label-delivery-check").html(i18n.t('step2.yes')); }
 
+// fieldValue returns the trimmed value of the given input with any line
+// breaks collapsed to spaces, so a multi-line value can't masquerade as
+// additional key=value lines in the note body.
+function fieldValue(selector) {
+  return ($(selector).val() || "").replace(/\s*[\r\n]+\s*/g, " ").trim();
+}
+
 function getNoteBody() {
   var paymentIds = [];
   $.each($("#payment").select2("data"), function (_, e) {
@@ -590,37 +596,36 @@ function getNoteBody() {
   });
 
   var note_body = "onosm.org submitted note from a business:\n";
-  if ($("#name").val()) note_body += "name=" + $("#name").val() + "\n";
-  if ($("#category").val()) note_body += "category=" + $("#category").val() + "\n";
-  if ($("#categoryalt").val()) note_body += "description=" + $("#categoryalt").val() + "\n";
-  if ($("#hnumberalt").val()) note_body += "addr:housenumber=" + $("#hnumberalt").val() + "\n";
-  if ($("#addressalt").val()) note_body += "addr:street=" + $("#addressalt").val() + "\n";
-  if ($("#placenamealt").val()) note_body += "addr:place=" + $("#placenamealt").val() + "\n";
-  if ($("#city").val()) note_body += "addr:city=" + $("#city").val() + "\n";
-  if ($("#postcode").val()) note_body += "addr:postcode=" + $("#postcode").val() + "\n";
-  if ($("#phone").val()) note_body += "phone=" + $("#phone").val() + "\n";
-  // fixme - this should be default to an empty string or be escaped
-  if ($("#website").val()) note_body += "website=" + $("#website").val() + "\n";
-  if ($("#social").val()) note_body += "social=" + $("#social").val() + "\n";
-  if ($("#opening_hours").val()) note_body += "opening_hours=" + $("#opening_hours").val() + "\n";
-  if ($("#wheel").val()) note_body += "wheelchair=" + $("#wheel").val() + "\n";
+  if (fieldValue("#name")) note_body += "name=" + fieldValue("#name") + "\n";
+  if (fieldValue("#category")) note_body += "category=" + fieldValue("#category") + "\n";
+  if (fieldValue("#categoryalt")) note_body += "description=" + fieldValue("#categoryalt") + "\n";
+  if (fieldValue("#hnumberalt")) note_body += "addr:housenumber=" + fieldValue("#hnumberalt") + "\n";
+  if (fieldValue("#addressalt")) note_body += "addr:street=" + fieldValue("#addressalt") + "\n";
+  if (fieldValue("#placenamealt")) note_body += "addr:place=" + fieldValue("#placenamealt") + "\n";
+  if (fieldValue("#city")) note_body += "addr:city=" + fieldValue("#city") + "\n";
+  if (fieldValue("#postcode")) note_body += "addr:postcode=" + fieldValue("#postcode") + "\n";
+  if (fieldValue("#phone")) note_body += "phone=" + fieldValue("#phone") + "\n";
+  if (fieldValue("#website")) note_body += "website=" + fieldValue("#website") + "\n";
+  if (fieldValue("#social")) note_body += "social=" + fieldValue("#social") + "\n";
+  if (fieldValue("#opening_hours")) note_body += "opening_hours=" + fieldValue("#opening_hours") + "\n";
+  if (fieldValue("#wheel")) note_body += "wheelchair=" + fieldValue("#wheel") + "\n";
   paymentIds.forEach(function (id) { note_body += id + "\n"; });
 
   // delivery
-  if ($("input:checked[name=delivery-check]").val() && $("#delivery").val() != "")
-    note_body += `delivery=${$("#delivery").val()}\n`;
-  else if ($("input:checked[name=delivery-check]").val() && $("#delivery").val() == "")
+  if ($("input:checked[name=delivery-check]").val() && fieldValue("#delivery") != "")
+    note_body += `delivery=${fieldValue("#delivery")}\n`;
+  else if ($("input:checked[name=delivery-check]").val() && fieldValue("#delivery") == "")
     note_body += "delivery=yes\n";
   else if ($('#delivery-check').not(':indeterminate') == true)
     note_body += "delivery=no\n";
 
-  if ($("#delivery_description").val()) note_body += `delivery:description=${$("#delivery_description").val()}\n`;
+  if (fieldValue("#delivery_description")) note_body += `delivery:description=${fieldValue("#delivery_description")}\n`;
 
   // take-away
   if ($("input:checked[name=takeaway]").val())
     note_body += `takeaway=${$("input:checked[name=takeaway]").val()}\n`;
-  if ($("#takeaway_description").val())
-    note_body += `takeaway:description=${$("#takeaway_description").val()}\n`;
+  if (fieldValue("#takeaway_description"))
+    note_body += `takeaway:description=${fieldValue("#takeaway_description")}\n`;
 
   // Source hashtag so notes from onosm.org (as opposed to one of its forks)
   // can be found/filtered, and the date lets us tell whether a given issue

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1,8 +1,8 @@
 ﻿{
   "app": {
     "title": "On OpenStreetMap",
-    "desc": "OpenStreetMap is an open, global map used by people around the world to navigate and find local businesses. It's easy and free to get on the map!"
-    "footer": "Source code available on <a href='https://github.com/osmlab/onosm.org'>GitHub</p>"
+    "desc": "OpenStreetMap is an open, global map used by people around the world to navigate and find local businesses. It's easy and free to get on the map!",
+    "footer": "Source code available on <a href='https://github.com/osmlab/onosm.org'>GitHub</a>"
   },
   "step1": {
     "title": "Location",


### PR DESCRIPTION
A batch of small correctness fixes, each verified end-to-end in a browser against a local copy of the site (address search, marker placement, form fill, stubbed note submission, and language switching):

- **Nominatim requests: JSONP → plain JSON with a 10s timeout.** Nominatim supports CORS, so the deprecated JSONP script-injection pattern (which also can't time out — the old `// should include a timeout` comment) is unnecessary.
- **Sanitize note body values** (resolves the `fixme` in `getNoteBody`): field values now have line breaks collapsed and whitespace trimmed, so a multi-line input can't inject extra `key=value` lines into the submitted note.
- **Pin Leaflet CSS to 1.9.3** to match the JS version (was 1.6.0 vs 1.9.3). This also makes the default marker icon load from the matching version.
- **Fix `locales/en/translation.json` syntax errors** (missing comma, `</p>` instead of `</a>`). This file is the language-only fallback i18next loads for browsers reporting plain `en`, and it has failed to parse since it was added.
- **Fix the language switcher handler in `i18n.js`**: it used `$(this)` inside an arrow function, so the chosen language was read from the wrong object. Now reads `event.target.value`. Also turn off i18next `debug` logging in production.
- **`.success()` → `.done()`** on jQuery requests in `reloadLists`. `.success()` was removed in jQuery 3 and only works via jquery-migrate. (Migrate itself has to stay for now: select2 3.5.4 uses the removed `.context` API.)
- **Remove the `lt IE 9` conditional stylesheet block**, which pointed at a plain-`http://` Leaflet 0.7.1 CDN URL.