### PR TITLE
Support #/edit/node/1234 links that prefill the form for suggesting changes to existing places

### DIFF
--- a/docs/superpowers/specs/2026-07-13-edit-existing-element-design.md
+++ b/docs/superpowers/specs/2026-07-13-edit-existing-element-design.md
@@ -1,0 +1,123 @@
+# Edit-existing-element links (`#/edit/node/1234`)
+
+**Date:** 2026-07-13
+**Status:** Approved
+
+## Purpose
+
+Let a mapper (or anyone) send a business owner a link like
+`https://onosm.org/#/edit/node/1234` that loads the existing OSM element,
+prefills the onosm.org form with its tags and location, and — on submit —
+creates an OSM note describing *only what changed*, referencing the element.
+This makes it easy for business owners to suggest corrections to existing
+places instead of only adding new ones.
+
+## URL scheme
+
+- Pattern: `#/edit/(node|way)/(\d+)`, also accepted without the leading
+  slash (`#edit/node/1234`).
+- Parsed at page load alongside the existing `#zoom/lat/lon` location-link
+  pattern in `js/site.js`; like that pattern, the hash is consumed and
+  cleared immediately so it doesn't interfere with the step-navigation
+  hashes (`#details`, `#done`).
+- Relations are out of scope (rare for POIs; centroid resolution is
+  disproportionately complex).
+
+## Fetching the element
+
+- Node: `GET https://api.openstreetmap.org/api/0.6/node/{id}.json`
+  (CORS-enabled; verified).
+- Way: `GET https://api.openstreetmap.org/api/0.6/way/{id}/full.json`;
+  marker position is the centroid (arithmetic mean) of the way's node
+  coordinates.
+- Error handling: HTTP 404, 410 (deleted), network/timeout failures, or an
+  element with no tags all show a dismissible warning ("Couldn't load that
+  OSM object") and fall back to the normal blank flow at step 1.
+
+## Edit context and prefill
+
+A module-level `editContext = { type, id, tags }` (null when not in edit
+mode) records the loaded element. Cleared when the form is reset after a
+successful submission (`#done` / `clearFields()`).
+
+Form fields prefill directly from tags:
+
+| Form field       | OSM tag(s), first match wins        |
+|------------------|-------------------------------------|
+| `#name`          | `name`                              |
+| `#phone`         | `phone`, `contact:phone`            |
+| `#website`       | `website`, `contact:website`        |
+| `#opening_hours` | `opening_hours`                     |
+| `#wheel`         | `wheelchair`                        |
+| `#hnumberalt`    | `addr:housenumber`                  |
+| `#addressalt`    | `addr:street`                       |
+| `#placenamealt`  | `addr:place`                        |
+| `#city`          | `addr:city`                         |
+| `#postcode`      | `addr:postcode`                     |
+
+- Address fields absent from the tags are filled from a Nominatim reverse
+  geocode of the element position (same flow as existing location links);
+  tag values always win over geocoder values.
+- Category picker stays blank. Instead, a read-only line near the form
+  shows the element's current main tags (`amenity`, `shop`, `tourism`,
+  `leisure`, `craft`, `office`, `cuisine`), e.g. "Currently tagged:
+  amenity=cafe". No tag→category-string mapping is attempted.
+- Payment/delivery/takeaway inputs are left untouched; if the user sets
+  one, it is included in the note as a suggested change.
+
+## Map step behavior
+
+Reuses `showFoundAddress()`: marker placed at the element position,
+geofence circle around it, step 1 auto-completed, and the user lands
+directly on `#details`. The marker remains draggable within the usual
+fence so "this place moved slightly" can be part of the suggestion.
+
+## Note body (diff format)
+
+In edit mode, `getNoteBody()` compares each field's submitted value
+against its prefilled tag value and emits only differences:
+
+```
+onosm.org suggested update to https://osm.org/node/1234 from the business:
+phone=+1 555 0100 (was +1 555 0199)
+opening_hours=Mo-Fr 09:00-17:00 (was Mo-Sa 08:00-18:00)
+website=https://example.com (new)
+
+#OnOSM.org-2026-07-13
+```
+
+- Changed field: `key=newvalue (was oldvalue)`.
+- Newly added field: `key=value (new)`.
+- Field cleared by the user: **ignored** (not reported as a removal) —
+  keeps accidental deletions out of notes; explicit removal suggestions
+  are a possible future extension.
+- If the marker moved more than ~10 m from the element position, a
+  `location moved to <lat>, <lon>` line is added.
+- If nothing changed (no field diffs and no marker move), submission is
+  blocked using the existing required-info alert styling with a
+  "you haven't changed anything yet" message.
+- The note is anchored at the marker position, as today.
+- The `#OnOSM.org-<date>` hashtag is kept.
+
+## i18n
+
+New strings in `locales/en/`, `locales/en-US/`, `locales/en-GB/`
+`translation.json` (other locales fall back to English):
+
+- edit-mode banner ("Suggesting changes to <link>")
+- current-tags label ("Currently tagged:")
+- fetch-error warning
+- nothing-changed validation message
+
+## Testing
+
+Manual verification via a local static server, consistent with the repo's
+no-test-harness setup:
+
+- `#/edit/node/<id>` for a tagged POI node → form prefilled, lands on
+  details, diff-only note body.
+- `#/edit/way/<id>` for a building POI → marker at centroid.
+- Deleted element (410), bogus ID (404), and untagged element → warning +
+  normal blank flow.
+- No-change submission blocked; changed submission produces correct diff.
+- Existing flows (`#zoom/lat/lon` links, plain search) unaffected.

--- a/index.html
+++ b/index.html
@@ -85,6 +85,7 @@
           </div>
         </form>
         <p id="couldnt-find" class="alert alert-danger mt-2" role="alert" style='display: none;' data-i18n="[html]step1.fail"></p>
+        <p id="edit-fetch-error" class="alert alert-warning mt-2" role="alert" style='display: none;' data-i18n="editmode.fetcherror"></p>
         <p id="map-information" class="alert alert-warning mt-2" role="alert" style='display: none;'></p>
       </div>
       <div id='findme-map'></div>
@@ -95,6 +96,12 @@
 
     <!-- step 2 -->
     <div class='mt-3 d-none' id='collect-data-step'>
+      <!-- Shown only when the form was reached via an #/edit/(node|way)/id
+           link (see loadElementForEditing() in js/site.js). -->
+      <div id="edit-mode-info" class="alert alert-info d-none" role="alert" dir="auto">
+        <div id="edit-mode-banner"></div>
+        <div id="edit-mode-tags" class="small"></div>
+      </div>
       <p data-i18n="[html]step2.desc" class="h3 text-info" dir="auto"></p>
       <form id="form" dir="auto">
         <!-- categories -->
@@ -318,6 +325,7 @@
         <div class="row">
           <div class="col">
               <p id="required_info_alert" class="alert alert-info" role="alert" data-i18n="step2.required"></p>
+              <p id="edit-nothing-changed-alert" class="alert alert-danger" role="alert" style="display: none;" data-i18n="editmode.nothingchanged"></p>
               <p id="submit-error" class="alert alert-danger" role="alert" style="display: none;" data-i18n="[html]step2.submitfail"></p>
           </div>
         </div>

--- a/js/site.js
+++ b/js/site.js
@@ -98,6 +98,13 @@ let circleBoundsVisible = true;
 // the address search. https://github.com/osmlab/onosm.org/issues/85
 const initialLocationMatch = location.hash.match(/^#(\d{1,2})\/(-?\d{1,2}(?:\.\d+)?)\/(-?\d{1,3}(?:\.\d+)?)$/);
 
+// A link like onosm.org/#/edit/node/1234 (or #edit/node/1234) loads that
+// existing OSM element for editing: the form is prefilled from its tags and
+// position so a mapper can send a business owner a link to suggest changes
+// to a place that's already on the map, instead of only adding new ones.
+// See docs/superpowers/specs/2026-07-13-edit-existing-element-design.md
+const initialEditMatch = location.hash.match(/^#\/?edit\/(node|way)\/(\d+)$/);
+
 if (location.hash) location.hash = '';
 
 if (initialLocationMatch) {
@@ -108,6 +115,249 @@ if (initialLocationMatch) {
       Number(initialLocationMatch[3]),
       Math.min(Number(initialLocationMatch[1]), 18));
   });
+}
+
+if (initialEditMatch) {
+  // wait for translations so the marker instructions / edit-mode banner
+  // render localized
+  i18n.on('initialized', function () {
+    loadElementForEditing(initialEditMatch[1], initialEditMatch[2]);
+  });
+}
+
+// editContext records the OSM element currently being edited (null when the
+// form is being used to add a brand-new place). Set by
+// loadElementForEditing() and cleared by clearFields(). See
+// docs/superpowers/specs/2026-07-13-edit-existing-element-design.md
+let editContext = null;
+
+// Tags shown in the read-only "Currently tagged:" line in edit mode.
+const editModeTagKeys = ['amenity', 'shop', 'tourism', 'leisure', 'craft', 'office', 'cuisine'];
+
+// Form field -> OSM tag(s) to prefill from, first match wins. Address fields
+// here are re-applied after showFoundAddress()/updateAddressInfo() runs so
+// that tag values win over the reverse geocoder's guess.
+const editPrefillTagMap = {
+  '#name': ['name'],
+  '#phone': ['phone', 'contact:phone'],
+  '#website': ['website', 'contact:website'],
+  '#opening_hours': ['opening_hours'],
+  '#hnumberalt': ['addr:housenumber'],
+  '#addressalt': ['addr:street'],
+  '#placenamealt': ['addr:place'],
+  '#city': ['addr:city'],
+  '#postcode': ['addr:postcode']
+};
+
+/**
+ * Load an existing OSM node or way for editing. Fetches the element from
+ * the OSM API, prefills the form from its tags/position, and reuses the
+ * showLinkedLocation() flow to drop the user directly onto the details
+ * step. Any fetch/parse failure just falls back to the normal blank flow
+ * with a dismissible warning -- this is a nice-to-have shortcut, not a
+ * required path. See
+ * docs/superpowers/specs/2026-07-13-edit-existing-element-design.md
+ * @param {"node"|"way"} type
+ * @param {string} id
+ */
+function loadElementForEditing(type, id) {
+  $("#findme").addClass("progress-bar progress-bar-striped progress-bar-animated");
+
+  const url = type === 'node'
+    ? 'https://api.openstreetmap.org/api/0.6/node/' + id + '.json'
+    : 'https://api.openstreetmap.org/api/0.6/way/' + id + '/full.json';
+
+  $.ajax({
+    url: url,
+    dataType: 'json',
+    timeout: 10000
+  })
+    .done(function (data) {
+      const extracted = extractEditElement(type, id, data);
+      if (!extracted) {
+        showEditFetchError();
+        return;
+      }
+
+      editContext = { type: type, id: id, tags: extracted.tags, lat: extracted.lat, lon: extracted.lon };
+      showEditModeBanner();
+
+      // Same flow as showLinkedLocation(): reverse-geocode the point for
+      // address fields, but keep the marker at the element's own position.
+      // Unlike a plain location link, a failed reverse geocode isn't fatal
+      // here -- the element itself is the source of truth, so continue with
+      // its tags alone rather than leaving edit mode half-initialized.
+      searchReverseLookup({ lat: extracted.lat, lon: extracted.lon })
+        .catch(() => ({ address: {}, display_name: '' }))
+        .then(foundAddress => {
+          const boxSize = 0.002;
+          foundAddress.lat = extracted.lat;
+          foundAddress.lon = extracted.lon;
+          foundAddress.boundingBox = [extracted.lat - boxSize, extracted.lat + boxSize, extracted.lon - boxSize, extracted.lon + boxSize];
+          activeSearchAddress = foundAddress;
+          showFoundAddress(foundAddress, 18);
+
+          // updateAddressInfo() (called from showFoundAddress) just filled
+          // the address fields from the geocoder -- now overwrite with tag
+          // values where the element actually has them.
+          prefillFromTags(editContext.tags);
+
+          $('#step2').removeClass("disabled");
+          $('.step-2 a').attr('href', '#details');
+          setContinueEnabled(true);
+
+          location.hash = '#details';
+        });
+    })
+    .fail(function () {
+      showEditFetchError();
+    })
+    .always(function () {
+      $("#findme").removeClass("progress-bar progress-bar-striped progress-bar-animated");
+    });
+}
+
+/**
+ * Pull the tags and a representative lat/lon out of an OSM API response for
+ * the element being edited. Returns null if the element (or its tags) can't
+ * be found, so the caller can fall back to the normal blank flow.
+ * @param {"node"|"way"} type
+ * @param {string} id
+ * @param {Object} data OSM API JSON response (node.json or way/full.json)
+ * @returns {?{tags: Object, lat: Number, lon: Number}}
+ */
+function extractEditElement(type, id, data) {
+  if (!data || !Array.isArray(data.elements)) return null;
+
+  const element = data.elements.find(function (e) {
+    return e.type === type && String(e.id) === String(id);
+  });
+
+  if (!element || !element.tags || Object.keys(element.tags).length === 0) return null;
+
+  if (type === 'node') {
+    return { tags: element.tags, lat: element.lat, lon: element.lon };
+  }
+
+  // way: centroid (arithmetic mean) of its member nodes' coordinates. A
+  // closed way repeats its first node id as the last one -- drop that
+  // duplicate so it isn't double-counted.
+  let nodeIds = element.nodes.slice();
+  if (nodeIds.length > 1 && nodeIds[0] === nodeIds[nodeIds.length - 1]) {
+    nodeIds = nodeIds.slice(0, -1);
+  }
+
+  const nodesById = {};
+  data.elements.forEach(function (e) {
+    if (e.type === 'node') nodesById[e.id] = e;
+  });
+
+  let sumLat = 0, sumLon = 0, count = 0;
+  nodeIds.forEach(function (nodeId) {
+    const node = nodesById[nodeId];
+    if (node) {
+      sumLat += node.lat;
+      sumLon += node.lon;
+      count++;
+    }
+  });
+
+  if (count === 0) return null;
+
+  return { tags: element.tags, lat: sumLat / count, lon: sumLon / count };
+}
+
+/**
+ * Prefill form fields from the edited element's tags (see editPrefillTagMap)
+ * and remember the prefilled value of each field on editContext.prefilled
+ * so getNoteBody() can later report only what changed. The category picker
+ * is intentionally left blank -- see showEditModeBanner() for the
+ * current-tags display instead.
+ * @param {Object} tags OSM tags of the element being edited
+ */
+function prefillFromTags(tags) {
+  Object.keys(editPrefillTagMap).forEach(function (selector) {
+    const tagKeys = editPrefillTagMap[selector];
+    for (let i = 0; i < tagKeys.length; i++) {
+      if (tags[tagKeys[i]]) {
+        $(selector).val(tags[tagKeys[i]]);
+        break;
+      }
+    }
+  });
+
+  // #wheel is a <select> restricted to a few known values; only prefill it
+  // when the tag value is one of the ones the form actually offers.
+  const wheelchair = tags['wheelchair'];
+  if (wheelchair === 'yes' || wheelchair === 'limited' || wheelchair === 'no') {
+    $('#wheel').val(wheelchair);
+  }
+
+  // Snapshot the resulting form values -- tag-derived AND geocoder-derived
+  // (updateAddressInfo() ran just before this) -- as the diff baseline.
+  // Snapshotting only tag values would make an untouched geocoder-filled
+  // field (say a city the element has no addr:city tag for) show up in the
+  // note as a spurious "(new)" suggestion and defeat the nothing-changed
+  // guard in editModeHasChanges().
+  editContext.prefilled = {};
+  editableFieldSpecs.forEach(function (f) {
+    editContext.prefilled[f.selector] = fieldValue(f.selector);
+  });
+}
+
+/**
+ * Leave edit mode: clear the edit context and its banner/alerts so the next
+ * note is a plain new-place submission. Called when the form is reset after
+ * a submission and when the user starts a fresh address search -- a manual
+ * search means they're describing some other place, and keeping the old
+ * editContext would make the note misattribute that place's details as
+ * changes to the originally linked element.
+ */
+function exitEditMode() {
+  editContext = null;
+  $('#edit-mode-info').addClass('d-none');
+  $('#edit-mode-banner').empty();
+  $('#edit-mode-tags').empty();
+  $('#edit-nothing-changed-alert').hide();
+}
+
+/**
+ * Show the dismissible "couldn't load that OSM object" warning used when
+ * loadElementForEditing() can't fetch or make sense of the linked element.
+ * The user is left on the normal blank flow.
+ */
+function showEditFetchError() {
+  $('#edit-fetch-error')
+    .text(i18n.t('editmode.fetcherror', { defaultValue: "Couldn't load that OSM object. You can still add a place normally." }))
+    .show();
+}
+
+/**
+ * Render the edit-mode banner ("Suggesting changes to node 1234") and the
+ * read-only "Currently tagged: amenity=cafe, ..." line shown on the details
+ * step while editContext is set.
+ */
+function showEditModeBanner() {
+  if (!editContext) return;
+
+  const osmUrl = 'https://osm.org/' + editContext.type + '/' + editContext.id;
+
+  const $banner = $('#edit-mode-banner').empty();
+  $banner.append(document.createTextNode(
+    i18n.t('editmode.banner', { defaultValue: 'Suggesting changes to' }) + ' '
+  ));
+  $('<a>').attr('href', osmUrl).text(editContext.type + ' ' + editContext.id).appendTo($banner);
+
+  const tagPairs = editModeTagKeys
+    .filter(function (key) { return editContext.tags[key]; })
+    .map(function (key) { return key + '=' + editContext.tags[key]; });
+
+  const $tags = $('#edit-mode-tags').empty();
+  if (tagPairs.length > 0) {
+    $tags.text(i18n.t('editmode.currenttags', { defaultValue: 'Currently tagged:' }) + ' ' + tagPairs.join(', '));
+  }
+
+  $('#edit-mode-info').removeClass('d-none');
 }
 
 /**
@@ -160,10 +410,13 @@ function showLinkedLocation(lat, lon, zoom) {
 $("#find").submit(function (e) {
   e.preventDefault();
   $("#couldnt-find").hide();
+  $("#edit-fetch-error").hide();
 
   // show loading indicator if user input is not empty
   let address_to_find = $("#address").val();
   if (address_to_find.length === 0) return;
+
+  exitEditMode();
 
   $("#findme h4").text(loadingText);
   $("#findme").addClass("progress-bar progress-bar-striped progress-bar-animated");
@@ -661,26 +914,84 @@ function fieldValue(selector) {
   return ($(selector).val() || "").replace(/\s*[\r\n]+\s*/g, " ").trim();
 }
 
+// editableFieldSpecs lists every form field that has a corresponding OSM
+// tag key in the note body, in the same order the note body has always used.
+// Shared by getNoteBody() (both plain and edit-mode/diff rendering) and
+// editModeHasChanges() (the "nothing changed" guard).
+const editableFieldSpecs = [
+  { selector: "#name", tag: "name" },
+  { selector: "#category", tag: "category" },
+  { selector: "#categoryalt", tag: "description" },
+  { selector: "#hnumberalt", tag: "addr:housenumber" },
+  { selector: "#addressalt", tag: "addr:street" },
+  { selector: "#placenamealt", tag: "addr:place" },
+  { selector: "#city", tag: "addr:city" },
+  { selector: "#postcode", tag: "addr:postcode" },
+  { selector: "#phone", tag: "phone" },
+  { selector: "#website", tag: "website" },
+  { selector: "#social", tag: "social" },
+  { selector: "#opening_hours", tag: "opening_hours" },
+  { selector: "#wheel", tag: "wheelchair" }
+];
+
+// noteBodyFieldLine renders one line of the note body for a field. Outside
+// edit mode this is unchanged from before: "key=value\n" when non-empty,
+// nothing otherwise. In edit mode it instead diffs the current value
+// against editContext.prefilled (fields with no tag counterpart -- category,
+// description, social, ... -- are treated as having had no prior value, so
+// any entered value shows as "(new)"), and cleared fields are silently
+// ignored rather than reported as removals.
+function noteBodyFieldLine(selector, tagKey) {
+  const newValue = fieldValue(selector);
+
+  if (!editContext) {
+    return newValue ? tagKey + "=" + newValue + "\n" : "";
+  }
+
+  if (!newValue) return "";
+
+  const oldValue = (editContext.prefilled && editContext.prefilled[selector]) || "";
+  if (newValue === oldValue) return "";
+
+  return oldValue
+    ? tagKey + "=" + newValue + " (was " + oldValue + ")\n"
+    : tagKey + "=" + newValue + " (new)\n";
+}
+
+// markerMoveDistanceMeters returns how far the marker has moved from the
+// edited element's original position, or 0 when not in edit mode / no
+// marker is placed yet.
+function markerMoveDistanceMeters() {
+  if (!editContext || !findme_marker) return 0;
+  return findme_map.distance(findme_marker.getLatLng(), { lat: editContext.lat, lng: editContext.lon });
+}
+
+// editModeHasChanges returns true when the user has actually suggested a
+// change to the edited element: a differing field or a marker move of more
+// than ~10 m. Used to block submitting a no-op edit-mode note.
+function editModeHasChanges() {
+  if (!editContext) return false;
+
+  const fieldChanged = editableFieldSpecs.some(function (f) {
+    return noteBodyFieldLine(f.selector, f.tag) !== "";
+  });
+
+  return fieldChanged || markerMoveDistanceMeters() > 10;
+}
+
 function getNoteBody() {
   var paymentIds = [];
   $.each($("#payment").select2("data"), function (_, e) {
     paymentIds.push(e.id);
   });
 
-  var note_body = "onosm.org submitted note from a business:\n";
-  if (fieldValue("#name")) note_body += "name=" + fieldValue("#name") + "\n";
-  if (fieldValue("#category")) note_body += "category=" + fieldValue("#category") + "\n";
-  if (fieldValue("#categoryalt")) note_body += "description=" + fieldValue("#categoryalt") + "\n";
-  if (fieldValue("#hnumberalt")) note_body += "addr:housenumber=" + fieldValue("#hnumberalt") + "\n";
-  if (fieldValue("#addressalt")) note_body += "addr:street=" + fieldValue("#addressalt") + "\n";
-  if (fieldValue("#placenamealt")) note_body += "addr:place=" + fieldValue("#placenamealt") + "\n";
-  if (fieldValue("#city")) note_body += "addr:city=" + fieldValue("#city") + "\n";
-  if (fieldValue("#postcode")) note_body += "addr:postcode=" + fieldValue("#postcode") + "\n";
-  if (fieldValue("#phone")) note_body += "phone=" + fieldValue("#phone") + "\n";
-  if (fieldValue("#website")) note_body += "website=" + fieldValue("#website") + "\n";
-  if (fieldValue("#social")) note_body += "social=" + fieldValue("#social") + "\n";
-  if (fieldValue("#opening_hours")) note_body += "opening_hours=" + fieldValue("#opening_hours") + "\n";
-  if (fieldValue("#wheel")) note_body += "wheelchair=" + fieldValue("#wheel") + "\n";
+  var note_body = editContext
+    ? "onosm.org suggested update to https://osm.org/" + editContext.type + "/" + editContext.id + " from the business:\n"
+    : "onosm.org submitted note from a business:\n";
+
+  editableFieldSpecs.forEach(function (f) {
+    note_body += noteBodyFieldLine(f.selector, f.tag);
+  });
   paymentIds.forEach(function (id) { note_body += id + "\n"; });
 
   // delivery
@@ -699,6 +1010,13 @@ function getNoteBody() {
   if (fieldValue("#takeaway_description"))
     note_body += `takeaway:description=${fieldValue("#takeaway_description")}\n`;
 
+  // If the marker was dragged away from the edited element's own position,
+  // record that as part of the suggestion too.
+  if (editContext && markerMoveDistanceMeters() > 10) {
+    const movedTo = findme_marker.getLatLng();
+    note_body += "location moved to " + movedTo.lat.toFixed(5) + ", " + movedTo.lng.toFixed(5) + "\n";
+  }
+
   // Source hashtag so notes from onosm.org (as opposed to one of its forks)
   // can be found/filtered, and the date lets us tell whether a given issue
   // has since been fixed. See https://github.com/osmlab/onosm.org/issues/117
@@ -709,8 +1027,13 @@ function getNoteBody() {
 }
 
 // hasMinimumData returns true if the form has the minimum data required to create a note.
-// We want to see at least a name, a city, and a category/description.
+// We want to see at least a name, a city, and a category/description. In
+// edit mode the category picker is intentionally left blank (see
+// showEditModeBanner()), so it isn't required there.
 function hasMinimumData() {
+  if (editContext) {
+    return $("#name").val() && $("#city").val();
+  }
   return $("#name").val() && $("#city").val() && ($("#category").val() || $("#categoryalt").val());
 }
 
@@ -729,6 +1052,8 @@ $("#collect-data-done").click(function (event) {
   // https://stackoverflow.com/questions/18274383/ajax-post-working-in-chrome-but-not-in-firefox
   event.preventDefault();
 
+  $("#edit-nothing-changed-alert").hide();
+
   // Don't submit if the form is invalid
   if (!hasMinimumData() || !hasValidLocation()) {
     event.stopPropagation();
@@ -737,6 +1062,16 @@ $("#collect-data-done").click(function (event) {
     if (!hasValidLocation()) {
       location.hash = '';
     }
+    return;
+  }
+
+  // In edit mode, don't let a no-op "note" go out just because the user
+  // clicked through without actually changing anything.
+  if (editContext && !editModeHasChanges()) {
+    event.stopPropagation();
+    $("#required_info_alert").removeClass("alert-info");
+    $("#required_info_alert").addClass("alert-danger");
+    $("#edit-nothing-changed-alert").show();
     return;
   }
 
@@ -792,4 +1127,6 @@ function clearFields() {
   $('#takeaway-description-group').addClass("d-none");
   $('#step2').addClass("disabled");
   setContinueEnabled(false);
+
+  exitEditMode();
 }

--- a/locales/en-GB/translation.json
+++ b/locales/en-GB/translation.json
@@ -89,5 +89,11 @@
     "modalTitle": "Wheelchair accessibility classification",
     "needsChecking": "needs checking",
     "credits": "An open source project developed by the worldwide <a href=\"https://www.openstreetmap.org/\" class=\"badge badge-info\">OpenStreetMap</a> community <i class=\"twa twa-globe-with-meridians\"></i>. Contribute to this project on <a href=\"https://github.com/osmlab/onosm.org\" class=\"badge badge-dark\">GitHub</a>."
+  },
+  "editmode": {
+    "banner": "Suggesting changes to",
+    "currenttags": "Currently tagged:",
+    "fetcherror": "Couldn't load that OSM object. You can still add a place normally.",
+    "nothingchanged": "You haven't changed anything yet."
   }
 }

--- a/locales/en-US/translation.json
+++ b/locales/en-US/translation.json
@@ -89,5 +89,11 @@
     "missingCategory": "Please select at least one category.",
     "missingName": "Please enter a name.",
     "missingPhoneOrWebsite": "Please enter a valid website or phone number."
+  },
+  "editmode": {
+    "banner": "Suggesting changes to",
+    "currenttags": "Currently tagged:",
+    "fetcherror": "Couldn't load that OSM object. You can still add a place normally.",
+    "nothingchanged": "You haven't changed anything yet."
   }
 }

--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -88,5 +88,11 @@
     "modalTitle": "Wheelchair accessibility classification",
     "needsChecking": "needs checking",
     "credits": "An open source project developed by the worldwide <a href=\"https://www.openstreetmap.org/\" class=\"badge badge-info\">OpenStreetMap</a> community <i class=\"twa twa-globe-with-meridians\"></i>. Contribute to this project on <a href=\"https://github.com/osmlab/onosm.org\" class=\"badge badge-dark\">GitHub</a>."
+  },
+  "editmode": {
+    "banner": "Suggesting changes to",
+    "currenttags": "Currently tagged:",
+    "fetcherror": "Couldn't load that OSM object. You can still add a place normally.",
+    "nothingchanged": "You haven't changed anything yet."
   }
 }


### PR DESCRIPTION
A link like `https://onosm.org/#/edit/node/1234` (or `#/edit/way/5678`) now loads that OSM element, prefills the form from its tags and position, and drops the user straight onto the details step. On submit, the note references the element and lists only what changed, so mappers can action it against the right object instead of guessing or creating a duplicate:

```
onosm.org suggested update to https://osm.org/node/1234 from the business:
phone=+1 503 555 0100 (was +15034778221)
website=https://example.com (new)

#OnOSM.org-2026-07-13
```

Details:

- Nodes and ways are supported (way position = centroid of its nodes); relations are out of scope.
- Tag values win over the reverse geocoder for address fields; the diff baseline is snapshotted after all prefilling so untouched geocoder values never show up as suggestions.
- The category picker stays blank (no fragile tag→category mapping); instead a read-only banner shows "Suggesting changes to node 1234" and its current main tags (amenity/shop/etc.).
- The marker stays draggable; a move of more than 10 m is reported as `location moved to <lat>, <lon>`.
- Cleared fields are ignored rather than reported as removals, and submitting with no changes at all is blocked.
- Fetch failures (deleted/bogus id, no tags, network) show a warning and fall back to the normal blank flow; a manual address search also exits edit mode so a stale edit link can't mislabel an unrelated note.

Verified with a headless-browser end-to-end run against the live OSM API covering node prefill + diff output, way centroid placement, bogus-id fallback, edit-mode exit on manual search, and no change to the existing note format outside edit mode.

Stacked on #167 (uses its hash-link handling); this PR is based on that branch and should retarget to gh-pages automatically when #167 merges.

Design doc: docs/superpowers/specs/2026-07-13-edit-existing-element-design.md