### PR TITLE
Add spaces to the text of notes

### DIFF
--- a/js/site.js
+++ b/js/site.js
@@ -945,7 +945,7 @@ function noteBodyFieldLine(selector, tagKey) {
   const newValue = fieldValue(selector);
 
   if (!editContext) {
-    return newValue ? tagKey + "=" + newValue + "\n" : "";
+    return newValue ? tagKey + " = " + newValue + "\n" : "";
   }
 
   if (!newValue) return "";
@@ -954,8 +954,8 @@ function noteBodyFieldLine(selector, tagKey) {
   if (newValue === oldValue) return "";
 
   return oldValue
-    ? tagKey + "=" + newValue + " (was " + oldValue + ")\n"
-    : tagKey + "=" + newValue + " (new)\n";
+    ? tagKey + " = " + newValue + " (was " + oldValue + ")\n"
+    : tagKey + " = " + newValue + " (new)\n";
 }
 
 // markerMoveDistanceMeters returns how far the marker has moved from the
@@ -996,19 +996,19 @@ function getNoteBody() {
 
   // delivery
   if ($("input:checked[name=delivery-check]").val() && fieldValue("#delivery") != "")
-    note_body += `delivery=${fieldValue("#delivery")}\n`;
+    note_body += `delivery = ${fieldValue("#delivery")}\n`;
   else if ($("input:checked[name=delivery-check]").val() && fieldValue("#delivery") == "")
-    note_body += "delivery=yes\n";
+    note_body += "delivery = yes\n";
   else if ($('#delivery-check').not(':indeterminate') == true)
-    note_body += "delivery=no\n";
+    note_body += "delivery = no\n";
 
-  if (fieldValue("#delivery_description")) note_body += `delivery:description=${fieldValue("#delivery_description")}\n`;
+  if (fieldValue("#delivery_description")) note_body += `delivery:description = ${fieldValue("#delivery_description")}\n`;
 
   // take-away
   if ($("input:checked[name=takeaway]").val())
-    note_body += `takeaway=${$("input:checked[name=takeaway]").val()}\n`;
+    note_body += `takeaway = ${$("input:checked[name=takeaway]").val()}\n`;
   if (fieldValue("#takeaway_description"))
-    note_body += `takeaway:description=${fieldValue("#takeaway_description")}\n`;
+    note_body += `takeaway:description = ${fieldValue("#takeaway_description")}\n`;
 
   // If the marker was dragged away from the edited element's own position,
   // record that as part of the suggestion too.


### PR DESCRIPTION
Recently, osm.org has been trying to make tags within text clickable. However, this doesn't work well for onosm notes, because in practice, most tag values ​​contain spaces:

<img width="294" height="374" src="https://github.com/user-attachments/assets/761d4ca7-b9a3-4e56-ba89-e7c54ae27cc0" />

The remaining links lead to non-existent wiki pages (for example, a phone number or opening hours)

I suggest adding spaces around the = sign:

<img width="318" height="251" src="https://github.com/user-attachments/assets/cba63f70-e9f8-4324-8d69-6dc3fc51f4f5" />
